### PR TITLE
Signaturi create message errors

### DIFF
--- a/packages/signaturi/__tests__/encode.spec.ts
+++ b/packages/signaturi/__tests__/encode.spec.ts
@@ -3,6 +3,9 @@ import {
     createSignaturiMessage,
     encodeMessage,
     SignaturiLengthMismatchError,
+    SignaturiNoAccountsError,
+    SignaturiNoContentError,
+    SignaturiNoSignaturesError,
 } from "../src/encode"
 
 describe('encodeMessage', () => {
@@ -126,6 +129,52 @@ describe('createSignaturiMessage', () => {
         })
     })
 
+    it('error if no accounts', async () => {
+        expect(() => createSignaturiMessage(
+           {
+               content: CONTENT,
+               accounts: [],
+           },
+           [
+               '0x17de0d62b42d355f097c9865811afa6574e46877ea5f5774b267ace41ee2d9a352743ff67ec92903121eeaf4f4d7d1dd0f87ddeace0a4f8fedb9fbe9bdb1eda31b',
+               null,
+                '0x0fb3fbdaa9b2410310a52fefd46e57fc9b6573d0808a27402373642bde4065f65984fe5bceffdbb5569c516c626381712b8429d01cd680e18c1a9e94dbe0219c1c',
+           ],
+        )).toThrow(new SignaturiNoAccountsError('Must provide at least one account.'))
+    })
+
+    it('error if no content', async () => {
+        expect(() => createSignaturiMessage(
+           {
+               content: '',
+               accounts: [
+                    ACCOUNT1,
+                    ACCOUNT2,
+                    ACCOUNT3,
+               ],
+           },
+           [
+               '0x17de0d62b42d355f097c9865811afa6574e46877ea5f5774b267ace41ee2d9a352743ff67ec92903121eeaf4f4d7d1dd0f87ddeace0a4f8fedb9fbe9bdb1eda31b',
+               null,
+                '0x0fb3fbdaa9b2410310a52fefd46e57fc9b6573d0808a27402373642bde4065f65984fe5bceffdbb5569c516c626381712b8429d01cd680e18c1a9e94dbe0219c1c',
+           ],
+        )).toThrow(new SignaturiNoContentError('Must provide some content.'))
+    })
+
+    it('error if no signatures', async () => {
+        expect(() => createSignaturiMessage(
+           {
+               content: CONTENT,
+               accounts: [
+                   ACCOUNT1,
+                   ACCOUNT2,
+                   ACCOUNT3,
+               ],
+           },
+           [],
+        )).toThrow(new SignaturiNoSignaturesError('Must provide signatures.'))
+    })
+
     it('error if fewer signatures than accounts', async () => {
         expect(() => createSignaturiMessage(
            {
@@ -159,4 +208,3 @@ describe('createSignaturiMessage', () => {
         )).toThrow(new SignaturiLengthMismatchError('Number of signatures does not match number of accounts.'))
     })
 })
-

--- a/packages/signaturi/__tests__/encode.spec.ts
+++ b/packages/signaturi/__tests__/encode.spec.ts
@@ -1,5 +1,9 @@
 import { ACCOUNT1, ACCOUNT2, ACCOUNT3, CONTENT } from "./helper"
-import { createSignaturiMessage, encodeMessage } from "../src/encode"
+import {
+    createSignaturiMessage,
+    encodeMessage,
+    SignaturiLengthMismatchError,
+} from "../src/encode"
 
 describe('encodeMessage', () => {
 
@@ -122,6 +126,37 @@ describe('createSignaturiMessage', () => {
         })
     })
 
-    // TODO: test error scenarios 
+    it('error if fewer signatures than accounts', async () => {
+        expect(() => createSignaturiMessage(
+           {
+               content: CONTENT,
+               accounts: [
+                   ACCOUNT1,
+                   ACCOUNT2,
+                   ACCOUNT3,
+               ],
+           },
+           [
+               '0x17de0d62b42d355f097c9865811afa6574e46877ea5f5774b267ace41ee2d9a352743ff67ec92903121eeaf4f4d7d1dd0f87ddeace0a4f8fedb9fbe9bdb1eda31b',
+           ],
+        )).toThrow(new SignaturiLengthMismatchError('Number of signatures does not match number of accounts.'))
+    })
+
+    it('error if more signatures than accounts', async () => {
+        expect(() => createSignaturiMessage(
+           {
+               content: CONTENT,
+               accounts: [
+                   ACCOUNT1,
+                   ACCOUNT3,
+               ],
+           },
+           [
+               '0x17de0d62b42d355f097c9865811afa6574e46877ea5f5774b267ace41ee2d9a352743ff67ec92903121eeaf4f4d7d1dd0f87ddeace0a4f8fedb9fbe9bdb1eda31b',
+               null,
+                '0x0fb3fbdaa9b2410310a52fefd46e57fc9b6573d0808a27402373642bde4065f65984fe5bceffdbb5569c516c626381712b8429d01cd680e18c1a9e94dbe0219c1c',
+           ],
+        )).toThrow(new SignaturiLengthMismatchError('Number of signatures does not match number of accounts.'))
+    })
 })
 

--- a/packages/signaturi/src/encode.ts
+++ b/packages/signaturi/src/encode.ts
@@ -1,9 +1,27 @@
 import { Signature } from "ethers";
 import { joinSignature, _TypedDataEncoder } from "ethers/lib/utils";
 import { EIP712_DOMAIN, EIP712_TYPES } from "./constants";
-import { EncodedMessage, InputMessage } from "./types";
+import { EncodedMessage, InputMessage, SignaturiError } from "./types";
 
-export class SignaturiLengthMismatchError extends Error {}
+export class SignaturiNoAccountsError extends SignaturiError {}
+export class SignaturiNoContentError extends SignaturiError {}
+export class SignaturiNoSignaturesError extends SignaturiError {}
+export class SignaturiLengthMismatchError extends SignaturiError {}
+
+function checkInput(input: InputMessage) {
+    if (!input || !input.content) {
+        throw new SignaturiNoContentError('Must provide some content.')
+    }
+    if (!input.accounts || input.accounts.length === 0 ) {
+        throw new SignaturiNoAccountsError('Must provide at least one account.')
+    }
+}
+
+function checkSignatures(signatures: unknown[]) {
+    if (!signatures || signatures.length === 0 ) {
+        throw new SignaturiNoSignaturesError('Must provide signatures.')
+    }
+}
 
 /**
    Encode a Signaturi-compatible message into an EIP-712 accounts to sign.
@@ -12,14 +30,17 @@ export class SignaturiLengthMismatchError extends Error {}
    https://eips.ethereum.org/EIPS/eip-712
    https://docs.ethers.org/v5/api/utils/hashing/#TypedDataEncoder
    **/
-export function encodeMessage(message: InputMessage) {
-    return _TypedDataEncoder.getPayload(EIP712_DOMAIN, EIP712_TYPES, message)
+export function encodeMessage(input: InputMessage) {
+    checkInput(input)
+    return _TypedDataEncoder.getPayload(EIP712_DOMAIN, EIP712_TYPES, input)
 }
 
 /// Creates a signaturi message that can be later verified for authenticity
 export function createSignaturiMessage(
     input: InputMessage, signatures: Array<Signature | string | null>
 ): EncodedMessage {
+    checkInput(input)
+    checkSignatures(signatures)
     if (input.accounts.length !== signatures.length) {
         throw new SignaturiLengthMismatchError('Number of signatures does not match number of accounts.')
     }

--- a/packages/signaturi/src/encode.ts
+++ b/packages/signaturi/src/encode.ts
@@ -3,6 +3,8 @@ import { joinSignature, _TypedDataEncoder } from "ethers/lib/utils";
 import { EIP712_DOMAIN, EIP712_TYPES } from "./constants";
 import { EncodedMessage, InputMessage } from "./types";
 
+export class SignaturiLengthMismatchError extends Error {}
+
 /**
    Encode a Signaturi-compatible message into an EIP-712 accounts to sign.
 
@@ -18,21 +20,9 @@ export function encodeMessage(message: InputMessage) {
 export function createSignaturiMessage(
     input: InputMessage, signatures: Array<Signature | string | null>
 ): EncodedMessage {
-    // TODO: sanity checks (throw SignaturiEncodeError)
-    // TODO: 1/ same length of signatures and accounts
-    // TODO: 2/ at least one non-null signature
-    // TODO: 3/ signatures are valid
-    // TODO: 4/ signatures match accounts
-    // const messageHash = hashMessage(input)
-    // Recover the addresses from the signatures
-    // const recoveredAddress1 = ethers.utils.recoverAddress(messageHash, await alice.signMessage(DATA));
-    // const recoveredAddress2 = ethers.utils.recoverAddress(messageHash, await bob.signMessage(DATA));
-    // const recoveredAddress3 = ethers.utils.recoverAddress(messageHash, await charlie.signMessage(DATA));
-    // // Check the recovered address against the expected address
-    // const isValidSignature = (recoveredAddress1.toLowerCase() === alice.address.toLowerCase() &&
-    //       recoveredAddress2.toLowerCase() === bob.address.toLowerCase() &&
-    //       recoveredAddress3.toLowerCase() === charlie.address.toLowerCase()
-    //                          ) ? true : false
+    if (input.accounts.length !== signatures.length) {
+        throw new SignaturiLengthMismatchError('Number of signatures does not match number of accounts.')
+    }
 
     // serialize all signatures into into string or null
     const serializedSignatures = signatures.map(

--- a/packages/signaturi/src/types.ts
+++ b/packages/signaturi/src/types.ts
@@ -1,3 +1,6 @@
+/// Base Signaturi error class, all other errors extend from it
+export class SignaturiError extends Error {}
+
 /// EVM account
 export interface Account {
     /// Human-readable name associated to the account (e.g. person name, ENS,


### PR DESCRIPTION
Check for some errors when calling `createSignaturiMessage`:

- No input message provided.
- No accounts provided.
- No content provided.
- No signatures provided.
- Number of signatures does not match number of accounts.